### PR TITLE
Update the panel location when its height changes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@ const Main = imports.ui.main;
 const PanelBox = Main.layoutManager.panelBox;
 
 let MonitorsChangedListener = null;
+let HeightNotifyListener = null;
 
 function _toTop() {
     PanelBox.set_anchor_point(0,0);
@@ -17,10 +18,14 @@ function init() { }
 
 function enable() {
     MonitorsChangedListener = global.screen.connect("monitors-changed", _toBottom);
+    HeightNotifyListener = PanelBox.connect("notify::height", _toBottom);
     _toBottom();
 }
 
 function disable() {
+    if(HeightNotifyListener !== null) {
+        PanelBox.disconnect(HeightNotifyListener);
+    }
     if(MonitorsChangedListener !== null) {
         global.screen.disconnect(MonitorsChangedListener);
     }


### PR DESCRIPTION
One commit that fixes a couple of glitches related to panel height.
- Some sort of race condition at login between extension enable() methods and the panel box's height being correctly reported for the eventual appearance - if the font scale factor is > 1.
- BottomPanel now responds to changes of the panel height for any reason, including the font scale factor.
