### PR TITLE
fix js error  "_rightPanelBarrier is null"

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -37,7 +37,9 @@ function _toBottom() {
         directions: Meta.BarrierDirection.NEGATIVE_Y
     });
     // TODO: find a way to replace the rightPanelBarrier instead of destroying
-    Main.layoutManager._rightPanelBarrier.destroy()
+    if (Main.layoutManager._rightPanelBarrier) {
+        Main.layoutManager._rightPanelBarrier.destroy()
+    }
     PanelBox.set_anchor_point(0,(-1)*(monitor.height-PanelBox.height));
 }
 


### PR DESCRIPTION
When this extension is enabled, I get an error in my log, and the extension is shown as being in an error state in gnome-tweaks, and it will not let me enable or disable it from there. The extension does actually still work despite this.

`JS ERROR: Extension bottompanel@tmoer93: TypeError: Main.layoutManager._rightPanelBarrier is null`

This change has resolved the issue for my system. I am on gnome 3.36, but also observed the issue on gnome 3.34.